### PR TITLE
#162705441 Admins can add centers

### DIFF
--- a/app/controllers/api/v1/centers_controller.rb
+++ b/app/controllers/api/v1/centers_controller.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 module Api::V1
   class CentersController < ApplicationController
-    def create
-      @center = Center.new(center_params)
+    # before_action :authenticate_user, only: %i[create update]
+    before_action :is_admin?, only: %i[create update]
 
-      if @center.save
-        json_response(@center, 'center', 'Center was successfully created', :created)
-        # render json: @center, status: :created
-      else
-        json_response(@center.errors, 'errors', 'Operation had some errors', :unprocessable_entity)
-        # render json: @center.errors, status: :unprocessable_entity
-      end
+    def create
+      @center = Center.create!(center_params)
+      json_response(@center, 'center', 'Center was successfully created', :created)
     end
 
     def update
@@ -25,7 +21,13 @@ module Api::V1
     private
 
     def center_params
-      params.require(:center).permit(:name, :description, :address, :capacity)
+      params.require(:center).permit(:name, :description, :address, :capacity, :image)
+    end
+
+    private
+
+    def is_admin?
+      head :forbidden unless current_user.admin
     end
   end
 end

--- a/app/models/center.rb
+++ b/app/models/center.rb
@@ -1,4 +1,4 @@
 class Center < ApplicationRecord
   validates_presence_of :name, :description, :address, :capacity
-  validates_uniqueness_of :name
+  validates_uniqueness_of :name, scope: :address, case_sensitive: false, message: "has been taken in the location specified"
 end

--- a/db/migrate/20190121105052_add_image_to_centers.rb
+++ b/db/migrate/20190121105052_add_image_to_centers.rb
@@ -1,0 +1,5 @@
+class AddImageToCenters < ActiveRecord::Migration[5.2]
+  def change
+    add_column :centers, :image, :string, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_26_000459) do
+ActiveRecord::Schema.define(version: 2019_01_21_105052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2018_12_26_000459) do
     t.integer "capacity", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "image", default: ""
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
#### What does this PR do?
Give admins the ability to add new centers
#### Description of Task to be completed?
- Give admins the ability to add new centers
#### How should this be manually tested?
* Log in as an admin user and grab the token that's returned
* Paste the token in the `headers` section under `Authorization`
* Send a POST request to `api/v1/centers` with the following object
```
{
  name: "string" (required),
  address: "string" (required),
  capacity: "integer" (required),
  image: "string",
  description: "string" (required)
}
```
* The center should be saved if there's not already an existing one in the database
* A request made by a non-admin user should return a `head :forbidden` error
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories? (if applicable)
[#162705441](https://www.pivotaltracker.com/story/show/162705441)