### PR TITLE
#162705454 Admins can update centers (API)

### DIFF
--- a/app/controllers/api/v1/centers_controller.rb
+++ b/app/controllers/api/v1/centers_controller.rb
@@ -3,32 +3,38 @@ module Api::V1
   class CentersController < ApplicationController
     # before_action :authenticate_user, only: %i[create update]
     before_action :is_admin?, only: %i[create update]
+    before_action :find_center, only: %i[update]
 
     def create
       @center = Center.create!(center_params)
-      @center.image.attach(params[:center][:image])
       json_response(@center, 'center', 'Center was successfully created', :created)
     end
 
     def update
-
+      @center.update!(center_params)
     end
 
     def index
-      @centers = Center.all
+      # .with_attached_image is a scope provided by ActiveStorage that helps reduce
+      # N + 1 queries when fetching images
+      @centers = Center.order_by_id.with_attached_image
       json_response(@centers, 'centers', 'List of centers', :ok)
     end
 
     private
 
     def center_params
-      params.require(:center).permit(:name, :description, :address, :capacity)
+      params.require(:center).permit(:name, :description, :address, :capacity, :image)
     end
 
     private
 
     def is_admin?
       head :forbidden unless current_user.admin
+    end
+
+    def find_center
+      @center = Center.find_by(id: params[:id])
     end
   end
 end

--- a/app/models/center.rb
+++ b/app/models/center.rb
@@ -5,4 +5,5 @@ class Center < ApplicationRecord
   validates :image, blob: {
     content_type: %w[image/png image/jpg image/jpeg]
   }
+  scope :order_by_id, -> { order(id: :asc) }
 end


### PR DESCRIPTION
#### What does this PR do?
Give admins the ability to update centers
#### Description of Task to be completed?
- Give admins the ability to update centers
- Sort centers by ID and not updated_at
#### How should this be manually tested?
* Send a `PUT` request to `http://{baseURL}/api/v1/centers/:id` with a payload in this format
```.json
{
  "center": {
    "name": "string",
    "address": "string",
    "capacity": "integer" ,
    "image": "string",
    "description": "string",
  }
}
```
* You should get a response notifying you of whether the request was successful or not
#### Any background context you want to provide?
Also reduced `N+1` queries using `ActiveStorage`'s `.with_attached_image` scope
#### What are the relevant pivotal tracker stories? (if applicable)
[#162705454](https://www.pivotaltracker.com/story/show/162705454)