### PR TITLE
Ch cleanup events and centers creation api 165944468

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 /coverage
 /public
 /client/build
+/node_modules

--- a/Guardfile
+++ b/Guardfile
@@ -58,6 +58,11 @@ guard :rspec, cmd: "bundle exec rspec" do
   watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
   watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
 
+  # spec changes
+  watch(%r{^app/(.+)\.rb$})                               { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^app/controllers/(.+)_controller\.rb$})        { |m| "spec/requests/#{m[1]}_spec.rb" }
+  watch(%r{^app/services/(.+)_service\.rb$})        { |m| "spec/services/#{m[1]}_spec.rb" }
+
   # Capybara features specs
   watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
   watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }

--- a/app/controllers/api/v1/centers_controller.rb
+++ b/app/controllers/api/v1/centers_controller.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 module Api::V1
   class CentersController < ApplicationController
-    # before_action :authenticate_user, only: %i[create update]
+    before_action :authenticate_user, only: %i[create update]
     before_action :is_admin?, only: %i[create update]
     before_action :find_center, only: %i[update show]
 
     def create
-      @center = Center.create!(center_params)
+      @center = current_user.centers.create!(center_params)
       json_response(@center, 'center', 'Center was successfully created', :created)
     end
 
@@ -20,9 +20,7 @@ module Api::V1
     end
 
     def index
-      # .with_attached_image is a scope provided by ActiveStorage that helps reduce
-      # N + 1 queries when fetching images
-      @centers = Center.order_by_id.with_attached_image
+      @centers = CenterService.fetch_centers(params)
       json_response(@centers, 'centers', 'List of centers', :ok)
     end
 
@@ -43,4 +41,3 @@ module Api::V1
     end
   end
 end
-# Center controller

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -1,7 +1,7 @@
 module Api::V1
   class EventsController < ApplicationController
     before_action :authenticate_user, only: %i[create update]
-    before_action :find_center, only: %i[create update index show]
+    before_action :find_center, only: %i[create]
     before_action :find_event, only: %i[show update destroy]
 
     def create
@@ -10,7 +10,7 @@ module Api::V1
     end
 
     def index
-      @events = @center.upcoming_events(params[:filter])
+      @events = EventService.fetch_events(params)
       json_response(@events, 'events', 'Successfully retrieved events', :ok)
     end
 
@@ -23,7 +23,7 @@ module Api::V1
     def event_params
       params.require(:event).permit(
         :name, :guests, :image, :description, :start_time, :end_time
-      )
+      ).merge!(user_id: current_user.id)
     end
 
     def find_center
@@ -31,7 +31,7 @@ module Api::V1
     end
 
     def find_event
-      @event = @center.find_event!(params[:id])
+      @event = Event.find_by!(id: params[:id])
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,21 +4,10 @@ class ApplicationController < ActionController::API
   include Error::ErrorHandler
   include ActionController::MimeResponds
 
-  around_action :set_user
-
   def fallback_index_html
     respond_to do |format|
       format.html { render body: Rails.root.join('public/index.html').read }
     end
     # render :file => 'public/index.html', :layout => false
-  end
-
-  def set_user
-    CurrentUser.user = current_user
-    yield
-  ensure
-    CurrentUser.user = nil
-    # to address the thread variable leak issues in Puma/Thin webserver (from StackOverflow)
-    # https://stackoverflow.com/questions/2513383/access-current-user-in-model
   end
 end

--- a/app/models/center.rb
+++ b/app/models/center.rb
@@ -1,4 +1,5 @@
 class Center < ApplicationRecord
+  belongs_to :user
   validates_presence_of :name, :description, :address, :capacity
   validates_uniqueness_of :name, scope: :address, case_sensitive: false, message: "has been taken in the location specified"
   has_one_attached :image

--- a/app/models/center.rb
+++ b/app/models/center.rb
@@ -12,7 +12,8 @@ class Center < ApplicationRecord
     events.order(created_at: :asc)
   end
 
-  def upcoming_events(filter)
+  def upcoming_events(filter=nil)
+    # binding.pry
     return all_events if filter.nil?
 
     events.where('start_time > ?', Time.now).order(created_at: :asc)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,17 +2,10 @@ class Event < ApplicationRecord
   include ActiveModel::Validations
   belongs_to :center
   belongs_to :user
-  before_validation :assign_user
 
   validates_presence_of :name, :description, :guests
-  validates_uniqueness_of :name, case_sensitive: false
+  validates_uniqueness_of :name, case_sensitive: false, scope: :center_id, message: "Name has already been taken in center"
   validates :start_time, timeliness: { type: :datetime }
   validates :end_time, timeliness: { type: :datetime }
-  # validate :time_overlaps, :dates_in_past, on: %i[create update]
   validates_with DatesValidator
-
-
-  def assign_user
-    self.user_id = CurrentUser.user.id # uses CurrentUser module in the concerns folder
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,14 @@ class User < ApplicationRecord
   # validates_uniqueness_of :email
   validates_presence_of :name, :email, :password, :password_confirmation
   validates :email, uniqueness: { case_sensitive: false}, format: { with: EmailValidation::REGEX }
+
+  def all_events
+    events.order(created_at: :asc)
+  end
+
+  def upcoming_events(filter=nil)
+    return all_events if filter.nil?
+
+    events.where('start_time > ?', Time.now).order(created_at: :asc)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,18 +2,29 @@ class User < ApplicationRecord
   include EmailValidation
   has_secure_password
   has_many :events
+  has_many :centers
 
   # validates_uniqueness_of :email
   validates_presence_of :name, :email, :password, :password_confirmation
   validates :email, uniqueness: { case_sensitive: false}, format: { with: EmailValidation::REGEX }
 
-  def all_events
-    events.order(created_at: :asc)
+  concerning :Events do
+    def all_events
+      events.order(created_at: :asc)
+    end
+
+    def upcoming_events(filter=nil)
+      return all_events if filter.nil?
+
+      events.where('start_time > ?', Time.now).order(created_at: :asc)
+    end
   end
 
-  def upcoming_events(filter=nil)
-    return all_events if filter.nil?
-
-    events.where('start_time > ?', Time.now).order(created_at: :asc)
+  concerning :Centers do
+    def all_centers
+      # .with_attached_image is a scope provided by ActiveStorage that helps reduce
+      # N + 1 queries when fetching images
+      centers.order_by_id.with_attached_image
+    end
   end
 end

--- a/app/services/center_service.rb
+++ b/app/services/center_service.rb
@@ -1,0 +1,11 @@
+class CenterService
+  class << self
+    def fetch_centers(params={})
+      if params[:user_id].present?
+        User.find_by!(id: params[:user_id]).all_centers
+      else
+        Center.order_by_id.with_attached_image
+      end
+    end
+  end
+end

--- a/app/services/event_service.rb
+++ b/app/services/event_service.rb
@@ -6,15 +6,8 @@ class EventService
       elsif params[:user_id].present?
         User.find_by(id: params[:user_id]).upcoming_events(params[:filter])
       else
-        handle_extra(params)
+        Event.all
       end
-    end
-
-    def handle_extra(params)
-      #  handle a case where someone is passing in a wrong key/value pair
-      return [] unless params.keys.count.zero?
-
-      Event.all
     end
   end
 end

--- a/app/services/event_service.rb
+++ b/app/services/event_service.rb
@@ -1,0 +1,20 @@
+class EventService
+  class << self
+    def fetch_events(params={})
+      if params[:center_id].present?
+        Center.find_by(id: params[:center_id]).upcoming_events(params[:filter])
+      elsif params[:user_id].present?
+        User.find_by(id: params[:user_id]).upcoming_events(params[:filter])
+      else
+        handle_extra(params)
+      end
+    end
+
+    def handle_extra(params)
+      #  handle a case where someone is passing in a wrong key/value pair
+      return [] unless params.keys.count.zero?
+
+      Event.all
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  post 'centers/create'
-  get 'centers', to: 'centers#index'
-
   concern :eventable do
     resources :events, shallow: true
   end
@@ -13,8 +10,9 @@ Rails.application.routes.draw do
       resources :events, only: :index
       resources :users do
         resources :events, only: :index
+        resources :centers, only: %i[index]
       end
-      post 'user_token' => 'user_token#create'
+      post 'login' => 'user_token#create'
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,12 +3,17 @@ Rails.application.routes.draw do
   post 'centers/create'
   get 'centers', to: 'centers#index'
 
+  concern :eventable do
+    resources :events, shallow: true
+  end
+
   namespace :api do
     namespace :v1 do
-      resources :centers do
-        resources :events
+      resources :centers, concerns: :eventable
+      resources :events, only: :index
+      resources :users do
+        resources :events, only: :index
       end
-      resources :users
       post 'user_token' => 'user_token#create'
     end
   end

--- a/db/migrate/20190528122042_add_user_to_centers.rb
+++ b/db/migrate/20190528122042_add_user_to_centers.rb
@@ -1,0 +1,5 @@
+class AddUserToCenters < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :centers, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_02_080408) do
+ActiveRecord::Schema.define(version: 2019_05_28_122042) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,8 @@ ActiveRecord::Schema.define(version: 2019_02_02_080408) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "image", default: ""
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_centers_on_user_id"
   end
 
   create_table "events", force: :cascade do |t|
@@ -70,6 +72,7 @@ ActiveRecord::Schema.define(version: 2019_02_02_080408) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "centers", "users"
   add_foreign_key "events", "centers"
   add_foreign_key "events", "users"
 end

--- a/lib/error/error_handler.rb
+++ b/lib/error/error_handler.rb
@@ -6,7 +6,7 @@ module Error
           respond(:unprocessable_entity, 422, e.to_s )
           end
         rescue_from ActiveRecord::RecordNotFound do |e|
-          respond(:not_found, 404, e.to_s )
+          respond(:not_found, 404, "Resource was not found" )
         end
         rescue_from ActiveSupport::MessageVerifier::InvalidSignature do |e|
           respond(:unprocessable_entity, 422, 'Invalid image file')

--- a/lib/validators/dates_validator.rb
+++ b/lib/validators/dates_validator.rb
@@ -10,7 +10,7 @@ class DatesValidator < ActiveModel::Validator
     elsif end_time < start_time
       record[:end_time] << 'is older than the start time'
     else
-      times = Center.find_by(id: record.center_id).events.pluck(:start_time, :end_time)
+      times = Center.find_by(id: record.center_id).all_events.pluck(:start_time, :end_time)
       time_group = { start_time: start_time, end_time: end_time }
       if DatesValidator.time_overlaps?(times, time_group) # uses time_overlaps? method in DateTimeHelpers module
         record.errors[:start_time] << 'or end time overlaps with existing time'

--- a/spec/factories/center.rb
+++ b/spec/factories/center.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     address { Faker::Address.street_name }
     description { Faker::Lorem.paragraph(3) }
     capacity { Faker::Number.number(4) }
+    user_id { create(:user).id }
   end
 end

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -15,5 +15,9 @@ FactoryBot.define do
     end
     center_id { create(:center).id }
     user_id { create(:user).id }
+
+    trait :skip_validate do
+      to_create {|instance| instance.save(validate: false)}
+    end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -3,12 +3,7 @@ RSpec.describe Event, type: :model do
   include CurrentUser
   let!(:new_user) { create :user }
   let!(:center) { create :center }
-  # let!(:events) { FactoryBot.create_list(:event, 10) }
-  subject { FactoryBot.create(:event) }
-  # binding.pry
-  before do
-    CurrentUser.user = new_user
-  end
+
   describe 'validate presence of attributes' do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:guests) }
@@ -21,12 +16,18 @@ RSpec.describe Event, type: :model do
   end
 
   describe 'validates uniqueness' do
-    subject { FactoryBot.build :event, center_id: center.id, user_id: new_user.id }
-    it { should validate_uniqueness_of(:name).case_insensitive }
+    let!(:event) { create :event, name: "kachi", center_id: center.id, user_id: new_user.id }
+
+    it "should raise an error if the event name exists for the center" do
+      event = FactoryBot.build(:event, name: "kachi", center_id: center.id, user_id: new_user.id)
+
+      expect(event).to_not be_valid
+      expect(event.errors.full_messages.to_sentence).to match "Name has already been taken in center"
+    end
   end
 
   describe 'when an event has an invalid datetime format' do
-    let(:event) { create :event, center_id: center.id, user_id: create(:user).id }
+    let(:event) { create :event, center_id: center.id, user_id: new_user.id }
 
     it 'should not be valid' do
       event.start_time = '2019-000-000'

--- a/spec/requests/api/v1/centers_spec.rb
+++ b/spec/requests/api/v1/centers_spec.rb
@@ -2,11 +2,12 @@
 require 'rails_helper'
 
 RSpec.describe 'Centers API', type: :request do
-  let!(:centers) { create_list :center, 10 }
+  let!(:user) { create :user, admin: true }
+  let!(:centers) { create_list :center, 10, user: user }
   let(:center_id) { centers.first.id }
 
   context 'GET /api/v1/centers' do
-    before { get '/api/v1/centers' }
+    before { get api_v1_centers_path }
 
     it 'returns the centers in the database' do
       expect(json).to_not be_empty
@@ -41,21 +42,18 @@ RSpec.describe 'Centers API', type: :request do
       end
 
       it 'should return an error message' do
-        expect(json["message"]).to eq "Couldn't find Center"
+        expect(json["message"]).to eq "Resource was not found"
       end
     end
   end
 
-  describe 'post /api/v1/centers' do
+  describe 'post /api/v1/users/:user_id/centers' do
     let(:params) {{ center: attributes_for(:center)}}
 
 
     context 'when it receives valid input' do
       let!(:user) { create :user, admin: true}
-      before(:each) do
-       headers = authenticated_headers(user.id)
-        post '/api/v1/centers', params: params, headers: headers
-      end
+      before { post api_v1_centers_path, params: params, headers: authenticated_headers(user.id) }
 
       it 'should return an object containing the newly created center' do
         expect(json).to_not be_empty
@@ -74,8 +72,7 @@ RSpec.describe 'Centers API', type: :request do
       before do
         invalid_params = { center: FactoryBot.attributes_for(:center) }
         invalid_params[:center].delete(:name)
-        headers = authenticated_headers(user.id)
-        post '/api/v1/centers', params: invalid_params, headers: headers
+        post api_v1_centers_path, params: invalid_params, headers: authenticated_headers(user.id)
       end
 
       it 'should return a 422' do

--- a/spec/requests/api/v1/events_spec.rb
+++ b/spec/requests/api/v1/events_spec.rb
@@ -125,15 +125,15 @@ RSpec.describe 'Events API' do
         end
       end
 
-      # context "when the center has no events" do
-      #   let!(:new_center) { create :center }
-      #   before { get api_v1_center_events_path(new_center.id) }
-      #
-      #   it "should return an empty array" do
-      #     expect(response).to have_http_status(200)
-      #     expect(json["data"]["events"].count).to eq 0
-      #   end
-      # end
+      context "when the center has no events" do
+        let!(:new_center) { create :center }
+        before { get api_v1_center_events_path(new_center.id) }
+
+        it "should return an empty array" do
+          expect(response).to have_http_status(200)
+          expect(json["data"]["events"].count).to eq 0
+        end
+      end
     end
 
     describe "when user is in params" do
@@ -195,7 +195,7 @@ RSpec.describe 'Events API' do
 
       it "should return an error" do
         expect(response).to have_http_status(404)
-        expect(json["message"]).to match "Couldn't find Event"
+        expect(json["message"]).to match "Resource was not found"
       end
     end
   end

--- a/spec/requests/api/v1/events_spec.rb
+++ b/spec/requests/api/v1/events_spec.rb
@@ -98,40 +98,80 @@ RSpec.describe 'Events API' do
   end
 
   describe "#index" do
-    context "when no upcoming flag is set in the query" do
-      let!(:events) { create_list :event, 5, center: center }
-      before { get api_v1_center_events_path(center_id) }
-
-      it "returns all the events" do
-        returned_events = json["data"]["events"]
-        expect(response).to have_http_status(200)
-        expect(returned_events.count).to eq 5
-        expect(returned_events.first["name"]).to eq Event.first.name
-      end
-    end
-
-    context "when an upcoming flag is set" do
+    describe "when center is in params" do
       before do
         travel_to Time.local(2018)
-        create_list :event, 5, center: center
+        create_list :event, 5, :skip_validate, center: center
         travel_back
-        create_list :event, 5, center: center
-        get api_v1_center_events_path(center_id), params: { filter: "upcoming" }
+        create_list :event, 5, :skip_validate, center: center
       end
-      it "returns only future events" do
-        returned_events = json["data"]["events"]
-        expect(response).to have_http_status(200)
-        expect(returned_events.count).to eq 5
+
+      context "when no upcoming flag is set in the query" do
+        before { get api_v1_center_events_path(center_id) }
+        it "returns all the events" do
+          returned_events = json["data"]["events"]
+          expect(response).to have_http_status(200)
+          expect(returned_events.count).to eq 10
+          expect(returned_events.first["name"]).to eq Event.first.name
+        end
       end
+
+      context "when an upcoming flag is set" do
+        before { get api_v1_center_events_path(center_id), params: { filter: "upcoming" } }
+        it "returns only future events" do
+          returned_events = json["data"]["events"]
+          expect(response).to have_http_status(200)
+          expect(returned_events.count).to eq 5
+        end
+      end
+
+      # context "when the center has no events" do
+      #   let!(:new_center) { create :center }
+      #   before { get api_v1_center_events_path(new_center.id) }
+      #
+      #   it "should return an empty array" do
+      #     expect(response).to have_http_status(200)
+      #     expect(json["data"]["events"].count).to eq 0
+      #   end
+      # end
     end
 
-    context "when the center has no events" do
-      let!(:new_center) { create :center }
-      before { get api_v1_center_events_path(new_center.id) }
+    describe "when user is in params" do
+      let!(:events) { create_list :event, 5, center: center, user: new_user }
+      before { get api_v1_user_events_path(user_id) }
+      context "when no upcoming flag is set in the query" do
+        it "returns all the events" do
+          returned_events = json["data"]["events"]
+          expect(response).to have_http_status(200)
+          expect(returned_events.count).to eq 5
+          expect(returned_events.first["name"]).to eq Event.first.name
+        end
+      end
 
-      it "should return an empty array" do
-        expect(response).to have_http_status(200)
-        expect(json["data"]["events"].count).to eq 0
+      context "when an upcoming flag is set" do
+        before do
+          travel_to Time.local(2018)
+          create_list :event, 5, :skip_validate, center: center
+          travel_back
+          create_list :event, 5, :skip_validate, center: center
+          get api_v1_user_events_path(user_id), params: { filter: "upcoming" }
+        end
+        it "returns only future events" do
+          returned_events = json["data"]["events"]
+          expect(response).to have_http_status(200)
+          expect(returned_events.count).to eq 5
+        end
+      end
+
+      context "when the user has no events" do
+        let!(:different_user) { create :user }
+        before { get api_v1_user_events_path(user_id: different_user.id) }
+
+        it "should return an empty array" do
+          expect(response).to have_http_status(200)
+          # binding.pry
+          expect(json["data"]["events"].count).to eq 0
+        end
       end
     end
   end
@@ -140,7 +180,7 @@ RSpec.describe 'Events API' do
     let!(:event) { create :event, center: center }
     let(:event_id) { event.id }
     context "when a valid ID is passed" do
-      before { get api_v1_center_event_path(center_id: center_id, id: event_id) }
+      before { get api_v1_event_path(id: event_id) }
 
       it "returns the actual event" do
         returned_event = json["data"]["event"]
@@ -151,17 +191,7 @@ RSpec.describe 'Events API' do
     end
 
     context "when an invalid event ID is passed" do
-      before { get api_v1_center_event_path(center_id: center_id, id: 1000) }
-
-      it "should return an error" do
-        expect(response).to have_http_status(404)
-        expect(json["message"]).to match "Couldn't find Event"
-      end
-    end
-
-    context "when the event isn't in a particular center" do
-      let!(:new_center) { create :center }
-      before { get api_v1_center_event_path(center_id: new_center.id, id: event_id) }
+      before { get api_v1_event_path(id: 1000) }
 
       it "should return an error" do
         expect(response).to have_http_status(404)

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -52,4 +52,30 @@ RSpec.describe 'Users API' do
       end
     end
   end
+
+  describe "login" do
+    let!(:user) { create :user }
+    let(:params) { { auth: { email: user.email, password: user.password }  } }
+
+    context "when valid params are passed" do
+      before do
+        post api_v1_login_path, params: params
+      end
+      it "should return a token" do
+        expect(response).to have_http_status 201
+        expect(json).to have_key("jwt")
+      end
+    end
+
+    context "when invalid params are passed in" do
+      before do
+        params[:auth][:password] = "stuff"
+        post api_v1_login_path, params: params
+      end
+      it "should return an error" do
+        expect(response).to have_http_status 404
+        expect(json["message"]).to match "Resource was not found"
+      end
+    end
+  end
 end

--- a/spec/services/center_service_spec.rb
+++ b/spec/services/center_service_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe CenterService do
+  let!(:user) { create :user }
+  let!(:unattached_centers) { create_list :center, 5 }
+  let(:user_params) { { user_id: user.id } }
+
+  context "when user_id is in params" do
+    let!(:centers) { create_list :center, 10, user: user }
+    it "returns centers created by the user" do
+      centers = CenterService.fetch_centers(user_params)
+      user_ids = centers.pluck(:user_id).uniq
+
+      expect(user_ids.count).to eq 1
+      expect(user_ids.first).to eq user.id
+      expect(centers).to eq centers
+    end
+  end
+
+  context "when no user id is passed" do
+    let!(:more_centers) { create_list :center, 10 }
+
+    it "returns all the centers" do
+      centers = CenterService.fetch_centers
+
+      expect(centers.count).to eq 15
+      expect(centers).to eq unattached_centers + more_centers
+    end
+  end
+
+  context "when invalid params are passed" do
+    let(:params) { { fish: "fs" } }
+
+    it "returns all the centers" do
+      centers = CenterService.fetch_centers(params)
+      expect(centers.count).to eq 5
+      expect(centers).to eq centers
+    end
+  end
+end

--- a/spec/services/event_service_spec.rb
+++ b/spec/services/event_service_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe EventService do
+  let!(:user) { create :user }
+  let!(:center) { create :center }
+  let!(:user_events) { create_list :event, 5, user: user }
+  let!(:center_events) { create_list :event, 5, center: center }
+
+
+  describe "when user id is in params" do
+    let!(:diff_events) { create_list :event, 5 }
+    let(:user_params) { { user_id: user.id } }
+
+    it "returns events for the user" do
+      events = EventService.fetch_events(user_params)
+      user_ids = events.pluck(:user_id).uniq
+
+      expect(events.count).to be 5
+      expect(user_ids.count).to eq 1
+      expect(user_ids.first).to eq user.id
+    end
+  end
+
+  describe "when center id is in params" do
+    let(:center_params) { { center_id: center.id } }
+    let!(:diff_events) { create_list :event, 5 }
+
+    it "should return only events for the center" do
+      events = EventService.fetch_events(center_params)
+      center_ids = events.pluck(:center_id).uniq
+
+      expect(events.count).to eq 5
+      expect(center_ids.count).to eq 1
+      expect(center_ids.first).to eq center.id
+    end
+  end
+
+  describe "when nothing is passed in" do
+    it "returns all the events in the database" do
+      events = EventService.fetch_events
+
+      expect(events.count).to eq 10
+    end
+  end
+
+  describe "when an invalid value is passed in the params" do
+    it "raises an error" do
+      event = ActionController::Parameters.new("echo": "echo")
+      events = EventService.fetch_events(event)
+
+      expect(events).to eq []
+    end
+  end
+end

--- a/spec/services/event_service_spec.rb
+++ b/spec/services/event_service_spec.rb
@@ -44,11 +44,11 @@ RSpec.describe EventService do
   end
 
   describe "when an invalid value is passed in the params" do
-    it "raises an error" do
-      event = ActionController::Parameters.new("echo": "echo")
-      events = EventService.fetch_events(event)
+    it "returns all the events" do
+      params = ActionController::Parameters.new("echo": "echo")
+      events = EventService.fetch_events(params)
 
-      expect(events).to eq []
+      expect(events).to eq user_events + center_events
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,8 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  config.filter_run_when_matching :focus
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin


### PR DESCRIPTION
#### What does this PR do?
Cleans up events and centers APIs'
#### Description of Task to be completed?
* Merge user_id into event_params in events_controller instead of setting it in the model
* Add service for fetching events
* Add `user_id` to `centers` table
* Cleanup routes
* Add service for fetching centers
* Modify `Guardfile`
#### How should this be manually tested?
* Changed login route from `/api/v1/auth_token` to `/api/v1/login` 
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories? (if applicable)
[#165944468](https://www.pivotaltracker.com/story/show/165944468)