### PR TITLE
validate dates for an event not attached to a center

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+AllCops:
+  Exclude:
+    - 'client/**/*'
+    - 'db/schema.rb'
+    - 'db/migrate/**/*'

--- a/app/models/concerns/date_time_helpers.rb
+++ b/app/models/concerns/date_time_helpers.rb
@@ -1,7 +1,7 @@
 module DateTimeHelpers
   def time_overlaps?(existing_times, new_time)
-    start_time = parse_datetime(new_time[:start_time].to_s, :start_time)
-    end_time = parse_datetime(new_time[:end_time].to_s, :end_time)
+    start_time = parse_datetime(new_time[:start_time].to_s)
+    end_time = parse_datetime(new_time[:end_time].to_s)
     times = existing_times.select do |time_group|
       # time_group[0] -> start times | time_group[1] -> end times
       start_time < time_group[1] && end_time > time_group[0]
@@ -16,8 +16,8 @@ module DateTimeHelpers
   end
 
   def dates_in_past?(record)
-    start_time = parse_datetime(record.start_time.to_s, :start_time)
-    end_time = parse_datetime(record.end_time.to_s, :end_time)
+    start_time = parse_datetime(record.start_time.to_s)
+    end_time = parse_datetime(record.end_time.to_s)
     if start_time < DateTime.now
       errors.add(:start_time, 'is in the past')
     end
@@ -27,12 +27,9 @@ module DateTimeHelpers
     end
   end
 
-  def parse_datetime(datetime, symbol)
-    begin
-      datetime = DateTime.parse(datetime)
-    rescue ArgumentError => e
-      errors.add(symbol, e.to_s)
-    end
-    datetime
+  def parse_datetime(datetime)
+    DateTime.parse(datetime)
+  rescue ArgumentError, TypeError
+    "not a valid datetime value"
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -19,5 +19,5 @@ class Event < ApplicationRecord
                           unless: -> { center.nil? }
   validates :start_time, timeliness: { type: :datetime }
   validates :end_time, timeliness: { type: :datetime }
-  validates_with DatesValidator, unless: -> { center.nil? }
+  validates_with DatesValidator
 end

--- a/lib/validators/dates_validator.rb
+++ b/lib/validators/dates_validator.rb
@@ -1,20 +1,52 @@
+# frozen_string_literal: true
+
+# class used to help validate dates
 class DatesValidator < ActiveModel::Validator
   extend DateTimeHelpers
   def validate(record)
     return if record.start_time.nil? || record.end_time.nil?
-    start_time = DatesValidator.parse_datetime(record.start_time.to_s, :start_time)
-    end_time = DatesValidator.parse_datetime(record.end_time.to_s, :end_time)
 
-    if start_time < DateTime.now
+    @start_time = DatesValidator.parse_datetime(record.start_time.to_s)
+    @end_time = DatesValidator.parse_datetime(record.end_time.to_s)
+
+    record.center.nil? ? with_event(record) : with_center(record)
+  end
+
+  private
+
+  def with_center(record)
+    check_time(record)
+
+    times = Center
+            .find_by(id: record.center_id)
+            .all_events.pluck(:start_time, :end_time)
+    time_group = { start_time: @start_time, end_time: @end_time }
+
+    # uses time_overlaps? method in DateTimeHelpers module
+    return unless DatesValidator.time_overlaps?(times, time_group)
+
+    message = 'Start time or end time overlaps with existing time'
+    record.errors[:start_time] << message
+  end
+
+  def with_event(record)
+    check_time(record)
+    times = User
+            .find_by(id: record.user_id)
+            .all_events.pluck(:start_time, :end_time)
+    time_group = { start_time: @start_time, end_time: @end_time }
+
+    return unless DatesValidator.time_overlaps?(times, time_group)
+
+    message = 'You have an overlapping event at this time'
+    record.errors[:start_time] << message
+  end
+
+  def check_time(record)
+    if @start_time < DateTime.now
       record.errors[:start_time] << 'Start time is in the past'
-    elsif end_time < start_time
-      record[:end_time] << 'End time is older than the start time'
-    else
-      times = Center.find_by(id: record.center_id).all_events.pluck(:start_time, :end_time)
-      time_group = { start_time: start_time, end_time: end_time }
-      if DatesValidator.time_overlaps?(times, time_group) # uses time_overlaps? method in DateTimeHelpers module
-        record.errors[:start_time] << 'Start time or end time overlaps with existing time'
-      end
+    elsif @end_time < @start_time
+      record.errors[:end_time] << 'End time is older than the start time'
     end
   end
 end


### PR DESCRIPTION
#### What does this PR do?
Validates dates for events that are not attached to a center
#### Description of Task to be completed?
  - run datetime validations when event isn't attached to a center
  - refactor dates_validator.rb
  - add .rubocop.yml file
  - prevent user from creating overlapping events when no center is attached
#### How should this be manually tested?
- Posting an event with no center and wrong dates should return an error
- Posting an event with no center at a time for when the user already has an existing event should return an error
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?(if applicable)