### PR TITLE
Return upcoming events

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,6 @@ AllCops:
     - 'client/**/*'
     - 'db/schema.rb'
     - 'db/migrate/**/*'
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/app/models/center.rb
+++ b/app/models/center.rb
@@ -19,10 +19,12 @@ class Center < ApplicationRecord
       .order(created_at: :asc)
   end
 
-  def upcoming_events(filter=nil)
-    return all_events if filter.nil?
-
+  def upcoming_events
     events.where('start_time > ?', Time.now).order(created_at: :asc)
+  end
+
+  def past_events
+    all_events.where('start_time < ?', Time.now).order(created_at: :asc)
   end
 
   def find_event!(id)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,4 +20,7 @@ class Event < ApplicationRecord
   validates :start_time, timeliness: { type: :datetime }
   validates :end_time, timeliness: { type: :datetime }
   validates_with DatesValidator
+
+  scope :upcoming_events, -> { where('start_time > ?', Time.now).order(created_at: :asc) }
+  scope :past_events, -> { where('start_time < ?', Time.now).order(created_at: :asc) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,10 +21,12 @@ class User < ApplicationRecord
         .order(created_at: :asc)
     end
 
-    def upcoming_events(filter=nil)
-      return all_events if filter.nil?
-
+    def upcoming_events
       all_events.where('start_time > ?', Time.now).order(created_at: :asc)
+    end
+
+    def past_events
+      all_events.where('start_time < ?', Time.now).order(created_at: :asc)
     end
   end
 

--- a/app/services/event_service.rb
+++ b/app/services/event_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class EventService
   def initialize(params)
     @event_params = params[:event_params]
@@ -13,11 +14,11 @@ class EventService
   class << self
     def fetch_events(params={})
       if params[:center_id].present?
-        events = Center.find_by(id: params[:center_id]).upcoming_events(params[:filter])
+        events = Center.find_by(id: params[:center_id]).upcoming_events
       elsif params[:user_id].present?
-        events = User.find_by(id: params[:user_id]).upcoming_events(params[:filter])
+        events = User.find_by(id: params[:user_id]).upcoming_events
       else
-        events = Event.includes([bookings: :user], :address, :center, :user).all
+        events = Event.upcoming_events
       end
       events
     end


### PR DESCRIPTION
#### What does this PR do?
Return only upcoming events
#### Description of Task to be completed?
  - return only upcoming events
  - add a method to return past events if needed later
  - add rubocop check to use double quotes
  - remove single quotes use in events_spec.rb
#### How should this be manually tested?
Fetching events should only return upcoming ones
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?(if applicable)
Basecamp - https://3.basecamp.com/4328072/buckets/14456421/todolists/2394936893